### PR TITLE
Add edit workout page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 
 # misc
 .DS_Store
+.claude/
 *.pem
 
 # debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ Before generating any code, always check the `/docs` directory for a relevant st
 - /docs/data-fetching.md
 - /docs/data-mutations.md
 - /docs/auth.md
+- /docs/routing.md
+- /docs/server-components.md
 
 ## Commands
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,51 @@
+# Routing
+
+## RULE: All app routes live under `/dashboard`
+
+Every page in this application must be nested under the `/dashboard` path. There are no top-level routes other than the root landing page.
+
+```
+src/app/
+  page.tsx                          # landing / marketing page
+  dashboard/
+    page.tsx                        # main dashboard
+    workout/
+      new/
+        page.tsx                    # create workout
+      [workoutId]/
+        page.tsx                    # edit workout
+```
+
+## RULE: All `/dashboard` routes are protected
+
+Every route under `/dashboard` must be accessible only to authenticated users. Unauthenticated users must be redirected to sign-in.
+
+## RULE: Route protection is handled by the Next.js proxy (middleware)
+
+Use the `proxy.ts` file (Next.js 15/16's renamed middleware) as the single place to enforce authentication on `/dashboard` routes. Do not add per-page auth guards in `page.tsx` files for the purpose of route protection.
+
+```ts
+// src/proxy.ts
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
+});
+
+export const config = {
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};
+```
+
+## Summary
+
+| Concern | Correct approach |
+|---|---|
+| Where app pages live | Under `/dashboard` |
+| Who can access `/dashboard` routes | Authenticated users only |
+| Where to enforce auth | `proxy.ts` (Next.js middleware) — not in individual pages |

--- a/docs/server-components.md
+++ b/docs/server-components.md
@@ -1,0 +1,63 @@
+# Server Components
+
+## RULE: Always await `params` and `searchParams`
+
+In Next.js 15+, `params` and `searchParams` are **Promises**. You must `await` them before accessing any values. Accessing them synchronously will result in a runtime error.
+
+```tsx
+// Correct
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ workoutId: string }>
+}) {
+  const { workoutId } = await params
+}
+
+// Wrong — synchronous access
+export default function Page({ params }: { params: { workoutId: string } }) {
+  const { workoutId } = params // runtime error in Next.js 15
+}
+```
+
+The same rule applies to `searchParams`:
+
+```tsx
+// Correct
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const { date } = await searchParams
+}
+```
+
+## RULE: Pages must be async Server Components when accessing route data
+
+Any page that reads `params` or `searchParams` must be an `async` function so that `await` can be used.
+
+```tsx
+// Correct
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ workoutId: string }>
+}) {
+  const { workoutId } = await params
+  // fetch data, render UI
+}
+
+// Wrong — non-async page cannot await params
+export default function Page({ params }: { params: Promise<{ workoutId: string }> }) {
+  const { workoutId } = await params // syntax error
+}
+```
+
+## Summary
+
+| Concern | Correct approach |
+|---|---|
+| Accessing `params` | Always `await` — it is a Promise in Next.js 15 |
+| Accessing `searchParams` | Always `await` — it is a Promise in Next.js 15 |
+| Page function signature | `async` whenever `params` or `searchParams` are used |

--- a/src/app/dashboard/workout/[workoutId]/_components/edit-workout-form.tsx
+++ b/src/app/dashboard/workout/[workoutId]/_components/edit-workout-form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { updateWorkoutAction } from "../actions";
+
+function formatDatetimeLocal(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+type Props = {
+  workoutId: number;
+  defaultName: string | null;
+  defaultStartedAt: Date;
+};
+
+export function EditWorkoutForm({ workoutId, defaultName, defaultStartedAt }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const name = (form.elements.namedItem("name") as HTMLInputElement).value;
+    const startedAtStr = (form.elements.namedItem("startedAt") as HTMLInputElement).value;
+
+    startTransition(async () => {
+      await updateWorkoutAction(workoutId, {
+        name,
+        startedAt: new Date(startedAtStr),
+      });
+      router.push("/dashboard");
+    });
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[580px]">
+      <h1 className="mb-8 text-3xl font-bold">Edit Workout</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="name">Workout Name</Label>
+          <Input
+            id="name"
+            name="name"
+            placeholder="Example workout"
+            maxLength={255}
+            defaultValue={defaultName ?? ""}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="startedAt">Start Time</Label>
+          <Input
+            id="startedAt"
+            name="startedAt"
+            type="datetime-local"
+            defaultValue={formatDatetimeLocal(defaultStartedAt)}
+            required
+          />
+        </div>
+        <div className="flex gap-3">
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Saving..." : "Save Changes"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push("/dashboard")}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/dashboard/workout/[workoutId]/actions.ts
+++ b/src/app/dashboard/workout/[workoutId]/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { z } from "zod";
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { updateWorkout } from "@/data/workouts";
+
+const UpdateWorkoutSchema = z.object({
+  name: z.string().max(255),
+  startedAt: z.date(),
+});
+
+export async function updateWorkoutAction(
+  workoutId: number,
+  input: { name: string; startedAt: Date }
+) {
+  const { userId } = await auth();
+  if (!userId) throw new Error("Unauthenticated");
+
+  const parsed = UpdateWorkoutSchema.parse(input);
+  const workout = await updateWorkout(userId, workoutId, parsed.name || null, parsed.startedAt);
+  revalidatePath("/dashboard");
+  return workout;
+}

--- a/src/app/dashboard/workout/[workoutId]/page.tsx
+++ b/src/app/dashboard/workout/[workoutId]/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { getWorkoutById } from "@/data/workouts";
+import { EditWorkoutForm } from "./_components/edit-workout-form";
+
+type Props = {
+  params: Promise<{ workoutId: string }>;
+};
+
+export default async function EditWorkoutPage({ params }: Props) {
+  const { workoutId } = await params;
+  const { userId } = await auth();
+  if (!userId) return notFound();
+
+  const workout = await getWorkoutById(userId, Number(workoutId));
+  if (!workout) return notFound();
+
+  return (
+    <main className="flex justify-center px-8 py-16">
+      <EditWorkoutForm
+        workoutId={workout.id}
+        defaultName={workout.name}
+        defaultStartedAt={workout.startedAt}
+      />
+    </main>
+  );
+}

--- a/src/data/workouts.ts
+++ b/src/data/workouts.ts
@@ -55,6 +55,28 @@ export async function getWorkoutsForDate(
   return Array.from(map.values());
 }
 
+export async function getWorkoutById(userId: string, workoutId: number) {
+  const [workout] = await db
+    .select()
+    .from(workouts)
+    .where(and(eq(workouts.id, workoutId), eq(workouts.userId, userId)));
+  return workout ?? null;
+}
+
+export async function updateWorkout(
+  userId: string,
+  workoutId: number,
+  name: string | null,
+  startedAt: Date
+) {
+  const [workout] = await db
+    .update(workouts)
+    .set({ name, startedAt })
+    .where(and(eq(workouts.id, workoutId), eq(workouts.userId, userId)))
+    .returning();
+  return workout;
+}
+
 export async function createWorkout(
   userId: string,
   name: string | null,


### PR DESCRIPTION
## Summary
- Add edit workout page with form pre-populated from existing workout data
- Add server action to update workout in the database
- Add `getWorkout` data fetching function to retrieve a single workout by ID
- Add routing and server component docs

## Test plan
- [ ] Navigate to a workout and verify the edit form loads with existing data
- [ ] Submit the form and verify the workout is updated in the database
- [ ] Verify redirect back to dashboard after successful update

🤖 Generated with [Claude Code](https://claude.com/claude-code)